### PR TITLE
Prevent stopwatch window from taking focus when appearing

### DIFF
--- a/Plugin/Ui/FloatingWindow.cs
+++ b/Plugin/Ui/FloatingWindow.cs
@@ -101,7 +101,8 @@ public sealed class FloatingWindow : IDisposable
         // ImGui.SetNextWindowBgAlpha(_configuration.FloatingWindow.FloatingWindowBackgroundColor.Z);
         ImGui.PushStyleColor(ImGuiCol.WindowBg, Plugin.Config.FloatingWindow.BackgroundColor);
 
-        var flags = ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoScrollbar;
+        var flags = ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoScrollbar |
+                    ImGuiWindowFlags.NoFocusOnAppearing;
         if (Plugin.Config.FloatingWindow.Lock) flags |= ImGuiWindowFlags.NoMouseInputs;
 
         if (ImGui.Begin("EngageTimer stopwatch", ref _stopwatchVisible, flags))


### PR DESCRIPTION
Adds the `ImGuiWindowFlags.NoFocusOnAppearing` flag to the floating stopwatch window. Without this flag, the window appearing at the start of combat can cause an active input box to lose focus or cause a plugin like Wotsit to close due to loss of focus. Since this is just an overlay which doesn't actually need focus, there should be no downside to setting this flag.