### PR TITLE
Add option to hide floating window timer while occupied in combat.

### DIFF
--- a/Plugin/Configuration/FloatingWindowConfiguration.cs
+++ b/Plugin/Configuration/FloatingWindowConfiguration.cs
@@ -54,6 +54,9 @@ public class FloatingWindowConfiguration
     [AutoField("Settings_FWTab_HideInCutscenes")]
     public bool HideInCutscenes { get; set; } = true;
 
+    [AutoField("Settings_FWTab_HideWhileOccupiedInCombat")]
+    public bool HideWhileOccupiedInCombat { get; set; } = false;
+
     [AutoField("Settings_FWTab_StopwatchAsSeconds")]
     public bool StopwatchAsSeconds { get; set; } = false;
 

--- a/Plugin/EngageTimer.csproj
+++ b/Plugin/EngageTimer.csproj
@@ -8,7 +8,7 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
-        <AssemblyVersion>2.4.1.2</AssemblyVersion>
+        <AssemblyVersion>2.4.1.3</AssemblyVersion>
         <Deterministic>false</Deterministic>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Plugin/Game/CountdownHook.cs
+++ b/Plugin/Game/CountdownHook.cs
@@ -64,6 +64,7 @@ public sealed class CountdownHook : IDisposable
         UpdateCountDown();
         _state.InInstance = Plugin.Condition[ConditionFlag.BoundByDuty];
         _state.InCutscene = Plugin.Condition[ConditionFlag.OccupiedInCutSceneEvent];
+        _state.OccupiedInCombat = Plugin.Condition[ConditionFlag.Occupied38];
     }
 
     private void UpdateCountDown()

--- a/Plugin/Properties/Strings.resx
+++ b/Plugin/Properties/Strings.resx
@@ -644,4 +644,7 @@ help text for the /eg settings command</comment>
     <data name="Settings_FWTab_HideInCutscenes" xml:space="preserve">
       <value>Hide in cutscenes</value>
     </data>
+    <data name="Settings_FWTab_HideWhileOccupiedInCombat" xml:space="preserve">
+      <value>Hide while occupied in combat.</value>
+    </data>
 </root>

--- a/Plugin/Status/State.cs
+++ b/Plugin/Status/State.cs
@@ -23,6 +23,7 @@ public class State
     private bool _countingDown;
     private bool _inCombat;
     public bool InCutscene { get; set; }
+    public bool OccupiedInCombat { get; set; }
     public TimeSpan CombatDuration { get; set; }
     public DateTime CombatEnd { get; set; }
     public DateTime CombatStart { get; set; }

--- a/Plugin/Ui/FloatingWindow.cs
+++ b/Plugin/Ui/FloatingWindow.cs
@@ -56,6 +56,8 @@ public sealed class FloatingWindow
         if (!displayStopwatch) return false;
 
         if (Plugin.Config.FloatingWindow.HideInCutscenes && Plugin.State.InCutscene) return false;
+        
+        if (Plugin.Config.FloatingWindow.HideWhileOccupiedInCombat && Plugin.State.OccupiedInCombat) return false;
 
         if (Plugin.Config.FloatingWindow.AutoHide &&
             (DateTime.Now - Plugin.State.CombatEnd).TotalSeconds > Plugin.Config.FloatingWindow.AutoHideTimeout)

--- a/Plugin/Ui/SettingsTab/FloatingWindowTab.cs
+++ b/Plugin/Ui/SettingsTab/FloatingWindowTab.cs
@@ -39,6 +39,13 @@ public static class FloatingWindowTab
         ImGuiComponents.HelpMarker(Strings.Settings_FWTab_Lock_Help);
 
         Components.AutoField(Plugin.Config.FloatingWindow, "HideInCutscenes");
+        if (Plugin.Config.FloatingWindow.HideInCutscenes)
+        {
+            ImGui.Indent();
+            Components.AutoField(Plugin.Config.FloatingWindow, "HideWhileOccupiedInCombat");
+            ImGui.Unindent();
+        }
+        
         Components.AutoField(Plugin.Config.FloatingWindow, "AutoHide");
         Components.AutoField(Plugin.Config.FloatingWindow, "AutoHideTimeout", sameLine: true);
 


### PR DESCRIPTION
Adds an option to the Floating Window timer to allow automatically hiding while the player is occupied during combat detected using ConditionFlag Occupied38. This addresses #77 

![image](https://github.com/user-attachments/assets/cf511e5e-fa59-40c1-88b2-ede3ab2f5ee0)
